### PR TITLE
Increase sharding for `parallel_hashmap` benchmark for fair comparison.

### DIFF
--- a/other/parallel_hashmap/unordered_map.h
+++ b/other/parallel_hashmap/unordered_map.h
@@ -5,7 +5,7 @@ template <typename K,
           class Hash = std::hash<K>,
           class KeyEqual = std::equal_to<K>>
 struct unordered_map {
-  using Table = phmap::parallel_flat_hash_map_m<K, V, Hash, KeyEqual>;
+   using Table = phmap::parallel_flat_hash_map<K, V, Hash, KeyEqual, std::allocator<std::pair<const K, V>>, 12, std::mutex>;
 
   Table table;
 


### PR DESCRIPTION
Hi. I'm the developer of `parallel_hashmap`. 
The default sharding is pretty low, this PR increases it and significantly improves the benchmark results.
I would very much appreciate if you updated the benchmark results in your Readme.md after this change.