### PR TITLE
Please use `invoke_result` instead of `result_of` for C++20 or later

### DIFF
--- a/include/parlay_hash/unordered_map.h
+++ b/include/parlay_hash/unordered_map.h
@@ -86,7 +86,7 @@ namespace parlay {
 
     template <typename F = decltype(get_value)>
     auto Find(const K& k, const F& f = get_value)
-      -> std::optional<typename std::result_of<F(value_type)>::type>
+      -> std::optional<typename std::invoke_result<F(value_type)>::type>
     {
       auto g = [&] (const Entry& e) {return f(e.get_entry());};
       return m.Find(Entry::make_key(k), g);
@@ -114,7 +114,7 @@ namespace parlay {
 
     template <typename F>
     auto Insert(const K& key, const V& value, const F& f)
-      -> std::optional<typename std::result_of<F(value_type)>::type>
+      -> std::optional<typename std::invoke_result<F(value_type)>::type>
     {
       auto k = Entry::make_key(key);
       auto g = [&] (const Entry& e) {return f(e.get_entry());};
@@ -129,7 +129,7 @@ namespace parlay {
 
     template <typename F>
     auto Remove(const K& k, const F& f)
-      -> std::optional<typename std::result_of<F(value_type)>::type>
+      -> std::optional<typename std::invoke_result<F(value_type)>::type>
     {
       auto g = [&] (const Entry& e) {return f(e.get_entry());};
       return m.Remove(Entry::make_key(k), g);


### PR DESCRIPTION
std::result_of` has been deprecated since 17 and removed since 20.

If you use parlayhash in C++20 or later, you must use `std::invoke_result` like any other header:
https://github.com/cmuparlay/parlayhash/blob/main/include/parlay_hash/parlay_hash.h#L175

invoke_result has been introduced since C++17, so it should work fine in environments that support parlayhash.
